### PR TITLE
전화번호 중복 확인 API 변경사항 적용

### DIFF
--- a/Projects/Feature/BaseFeature/Sources/ErrorType.swift
+++ b/Projects/Feature/BaseFeature/Sources/ErrorType.swift
@@ -2,3 +2,8 @@ public enum PhoneNumberErrorType: Error {
     case cantSendAuthNumber
     case tooManyRequestException
 }
+
+public enum CheckPhoneDuplicateErrorType: Error {
+    case cantFindPhoneNumber
+    case duplicatePhoneNumber
+}

--- a/Projects/Feature/BaseFeature/Sources/ErrorType.swift
+++ b/Projects/Feature/BaseFeature/Sources/ErrorType.swift
@@ -6,4 +6,5 @@ public enum PhoneNumberErrorType: Error {
 public enum CheckPhoneDuplicateErrorType: Error {
     case cantFindPhoneNumber
     case duplicatePhoneNumber
+    case faildRequest
 }

--- a/Projects/Feature/BaseFeature/Sources/Type.swift
+++ b/Projects/Feature/BaseFeature/Sources/Type.swift
@@ -4,5 +4,5 @@ public enum FindAccountType {
 
 public enum CheckPhoneDuplicateType {
     public static let signup = "SIGNUP"
-    public static let password = "PASSWORD"
+    public static let findAccount = "FIND_ACCOUNT"
 }

--- a/Projects/Feature/PhoneNumberAuthFeature/Sources/InputPhoneNumberViewController.swift
+++ b/Projects/Feature/PhoneNumberAuthFeature/Sources/InputPhoneNumberViewController.swift
@@ -39,8 +39,10 @@ extension InputPhoneNumberViewController {
             switch result {
             case .success:
                 self?.requestToSendAuthNumber(phoneNumber: phoneNumber)
-            case .failure:
-                self?.component.errorLabel.text = "이미 등록된 전화번호 입니다."
+            case .failure(.cantFindPhoneNumber):
+                self?.component.errorLabel.text = "등록되지 않은 전화번호 입니다."
+            default:
+                self?.component.errorLabel.text = "인증에 실패했습니다."
             }
         }
     }

--- a/Projects/Feature/PhoneNumberAuthFeature/Sources/InputPhoneNumberViewModel.swift
+++ b/Projects/Feature/PhoneNumberAuthFeature/Sources/InputPhoneNumberViewModel.swift
@@ -23,11 +23,11 @@ public class InputPhoneNumberViewModel: BaseViewModel {
     }
     
     func requestToCheckDuplicationPhoneNumber(phoneNumber: String, completion: @escaping (Result<Void, CheckPhoneDuplicateErrorType>) -> Void = { _ in }) {
-        AF.request(PhoneNumberAuthTarget.checkPhoneNumberDuplication(phoneNumber: phoneNumber))
+        AF.request(PhoneNumberAuthTarget.checkPhoneNumberDuplication(phoneNumber: phoneNumber, type: CheckPhoneDuplicateType.findAccount))
             .validate()
             .responseData { response in
                 switch response.response?.statusCode {
-                case 204:
+                case 200:
                     completion(.success(()))
                 case 404:
                     completion(.failure(.cantFindPhoneNumber))

--- a/Projects/Feature/PhoneNumberAuthFeature/Sources/InputPhoneNumberViewModel.swift
+++ b/Projects/Feature/PhoneNumberAuthFeature/Sources/InputPhoneNumberViewModel.swift
@@ -22,16 +22,19 @@ public class InputPhoneNumberViewModel: BaseViewModel {
             }
     }
     
-    func requestToCheckDuplicationPhoneNumber(phoneNumber: String, completion: @escaping (Result<Void, Error>) -> Void = { _ in }) {
+    func requestToCheckDuplicationPhoneNumber(phoneNumber: String, completion: @escaping (Result<Void, CheckPhoneDuplicateErrorType>) -> Void = { _ in }) {
         AF.request(PhoneNumberAuthTarget.checkPhoneNumberDuplication(phoneNumber: phoneNumber))
             .validate()
             .responseData { response in
-                switch response.result {
-                case .success:
+                switch response.response?.statusCode {
+                case 204:
                     completion(.success(()))
-                case .failure(let error):
-                    completion(.failure(error))
-                    print("Error - inputPhoneNumber = \(error.localizedDescription)")
+                case 404:
+                    completion(.failure(.cantFindPhoneNumber))
+                    print("Error - inputPhoneNumber = \(response.response?.statusCode)")
+                default:
+                    completion(.failure(.faildRequest))
+                    print("Error - inputPhoneNumber = \(response.response?.statusCode)")
                 }
             }
     }

--- a/Projects/Feature/PhoneNumberAuthFeature/Sources/PhoneNumberAuthTarget.swift
+++ b/Projects/Feature/PhoneNumberAuthFeature/Sources/PhoneNumberAuthTarget.swift
@@ -3,7 +3,7 @@ import Alamofire
 import AuthDomain
 
 enum PhoneNumberAuthTarget {
-    case checkPhoneNumberDuplication(phoneNumber: String)
+    case checkPhoneNumberDuplication(phoneNumber: String, type: String)
     case sendAuthNumber(phoneNumber: String)
     case checkAuthNumber(authCode: String, phoneNumber: String)
 }
@@ -23,8 +23,8 @@ extension PhoneNumberAuthTarget: BaseRouter {
     
     var path: String {
         switch self {
-        case .checkPhoneNumberDuplication(let phoneNumber):
-            return "/auth/check/phone-number/\(phoneNumber)"
+        case .checkPhoneNumberDuplication(let phoneNumber, let type):
+            return "/auth/check/phone-number/\(phoneNumber)/type/\(type)"
         case .sendAuthNumber(phoneNumber: let phoneNumber):
             return "/auth/send/phone-number/\(phoneNumber)"
         case .checkAuthNumber(authCode: let authCode, phoneNumber: let phoneNumber):

--- a/Projects/Feature/SignupFeature/Sources/PhoneNumber/SignupPhoneNumberViewController.swift
+++ b/Projects/Feature/SignupFeature/Sources/PhoneNumber/SignupPhoneNumberViewController.swift
@@ -31,8 +31,10 @@ extension SignupPhoneNumberViewController {
             switch result {
             case .success:
                 self?.requestToSendAuthNumber(phoneNumber: phoneNumber)
-            case .failure:
+            case .failure(.duplicatePhoneNumber):
                 self?.component.errorLabel.text = "이미 등록된 전화번호 입니다."
+            default:
+                self?.component.errorLabel.text = "인증에 실패했습니다."
             }
         }
     }

--- a/Projects/Feature/SignupFeature/Sources/PhoneNumber/SignupPhoneNumberViewModel.swift
+++ b/Projects/Feature/SignupFeature/Sources/PhoneNumber/SignupPhoneNumberViewModel.swift
@@ -31,15 +31,17 @@ class SignupPhoneNumberViewModel: BaseViewModel {
             }
     }
     
-    func requestToCheckDuplicationPhoneNumber(phoneNumber: String, completion: @escaping (Result<Void, Error>) -> Void = { _ in }) {
+    func requestToCheckDuplicationPhoneNumber(phoneNumber: String, completion: @escaping (Result<Void, CheckPhoneDuplicateErrorType>) -> Void = { _ in }) {
         AF.request(SignupTarget.checkPhoneNumberDuplication(phoneNumber: phoneNumber, type: CheckPhoneDuplicateType.signup))
             .validate()
             .responseData { response in
                 switch response.response?.statusCode {
                 case 204:
                     completion(.success(()))
-                case 409(let error):
-                    completion
+                case 409:
+                    completion(.failure(.duplicatePhoneNumber))
+                default:
+                    completion(.failure(.faildRequest))
                 }
             }
     }

--- a/Projects/Feature/SignupFeature/Sources/PhoneNumber/SignupPhoneNumberViewModel.swift
+++ b/Projects/Feature/SignupFeature/Sources/PhoneNumber/SignupPhoneNumberViewModel.swift
@@ -35,12 +35,11 @@ class SignupPhoneNumberViewModel: BaseViewModel {
         AF.request(SignupTarget.checkPhoneNumberDuplication(phoneNumber: phoneNumber, type: CheckPhoneDuplicateType.signup))
             .validate()
             .responseData { response in
-                switch response.result {
-                case .success:
+                switch response.response?.statusCode {
+                case 204:
                     completion(.success(()))
-                case .failure(let error):
-                    completion(.failure(error))
-                    print("Error - inputPhoneNumber = \(error.localizedDescription)")
+                case 409(let error):
+                    completion
                 }
             }
     }

--- a/Projects/Feature/SignupFeature/Sources/SignupTarget.swift
+++ b/Projects/Feature/SignupFeature/Sources/SignupTarget.swift
@@ -32,8 +32,8 @@ extension SignupTarget: BaseRouter {
         switch self {
         case .signup:
             return "/auth/signup"
-        case .checkPhoneNumberDuplication(let phoneNumber):
-            return "/auth/check/phone-number/\(phoneNumber)"
+        case .checkPhoneNumberDuplication(let phoneNumber, let type):
+            return "/auth/check/phone-number/\(phoneNumber)/type/\(type)"
         case .checkIdDuplication(id: let id):
             return "/auth/check/id/\(id)"
         case .sendAuthNumber(phoneNumber: let phoneNumber):


### PR DESCRIPTION
## 제목
전화번호 중복 확인 API 변경사항을 적용했습니다.
- 계정 찾기와, 회원가입 시 전화번호 중복을 확인하는 같은 API 를 사용하는데, 이를 type 으로 구분할 수 있도록 변경되었습니다.
(SIGNUP, FIND_ACCOUNT)