### PR TITLE
Fix 크라우드 펀딩 디테일 페이지 이미지

### DIFF
--- a/Projects/Feature/CrowdFundingFeature/Sources/CrowdFundingViewController.swift
+++ b/Projects/Feature/CrowdFundingFeature/Sources/CrowdFundingViewController.swift
@@ -195,11 +195,11 @@ class CrowdFundingViewController: BaseVC<CrowdFundingViewModel> {
         viewModel.requestCrowdFundingList()
             .observe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, model in
-                owner.configure(model: model)
-                
                 owner.attachmentBehaviorRelay.accept(model.imageList)
                 owner.fundingImageDataSources.accept(model.imageList)
                 owner.rewardBehaviorRelay.accept(model.reward)
+                
+                owner.configure(model: model)
             }.disposed(by: disposeBag)
     }
     
@@ -207,22 +207,20 @@ class CrowdFundingViewController: BaseVC<CrowdFundingViewModel> {
         self.attachmentListTableView.removeObserver(self, forKeyPath: ContentSizeKey.key)
         self.rewardListTableView.removeObserver(self, forKeyPath: ContentSizeKey.key)
     }
-
+    
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == ContentSizeKey.key {
             if object is UITableView {
-                if let newValue = change?[.newKey] as? CGSize {
-                    attachmentListTableView.snp.updateConstraints {
-                        $0.height.equalTo(
-                            attachmentListTableView.rowHeight * CGFloat(attachmentBehaviorRelay.value.count)
-                        )
-                    }
-                    
-                    rewardListTableView.snp.updateConstraints {
-                        $0.height.equalTo(
-                            rewardListTableView.rowHeight * CGFloat(rewardBehaviorRelay.value.count)
-                        )
-                    }
+                attachmentListTableView.snp.updateConstraints {
+                    $0.height.equalTo(
+                        attachmentListTableView.rowHeight * CGFloat(attachmentBehaviorRelay.value.count)
+                    )
+                }
+                
+                rewardListTableView.snp.updateConstraints {
+                    $0.height.equalTo(
+                        rewardListTableView.rowHeight * CGFloat(rewardBehaviorRelay.value.count)
+                    )
                 }
             }
         }


### PR DESCRIPTION
## 이런 문제가 있었습니다.
크라우드 펀딩 디테일 페이지에서 imageList 에 값이 있음에도 불구하고 처음 configure 에 바로 적용되지 않는 문제가 있었습니다.
처음에 적용되지 않고 스와이프 시 적용되는 문제였습니다.
<img width="410" alt="스크린샷 2023-07-05 오후 1 54 16" src="https://github.com/Dan-Bam/IndiStraw-iOS/assets/81687906/72eec6a5-c038-462e-9da3-afaa68b77c2b">

## 이렇게 해결했습니다.
dataSource에 먼저 accept 하고 configure 함수를 실행했습니다.
<img width="393" alt="스크린샷 2023-07-05 오후 1 57 48" src="https://github.com/Dan-Bam/IndiStraw-iOS/assets/81687906/ec0a6509-1f7f-49b2-928b-e16f660ee346">
