### PR TITLE
PageControl 컴포넌트화 & Fix SegmentedControl

### DIFF
--- a/Projects/Core/DesignSystem/Sources/ImageViewPageControl.swift
+++ b/Projects/Core/DesignSystem/Sources/ImageViewPageControl.swift
@@ -6,15 +6,14 @@ import RxSwift
 import RxCocoa
 import RxGesture
 
-class ImageViewPageControl: UIView {
+public class ImageViewPageControl: UIView {
     private let disposeBag = DisposeBag()
-    private let imageDataSources = BehaviorRelay<[String]>(value: [])
+    private let imageDataSources = BehaviorRelay<[String]>(value: [""])
     
     private let pagecontrolImageView = UIImageView().then {
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 10
         $0.backgroundColor = DesignSystemAsset.Colors.gray.color
-//        $0.image = bannerImageSources[0]
     }
     
     private let pageControl = UIPageControl().then {
@@ -74,7 +73,7 @@ class ImageViewPageControl: UIView {
     private func setLayout() {
         pagecontrolImageView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
-            $0.height.equalTo(170)
+            $0.height.equalTo(140)
         }
         
         pageControl.snp.makeConstraints {
@@ -85,8 +84,10 @@ class ImageViewPageControl: UIView {
     }
 }
 
-extension ImageViewPageControl {
+public extension ImageViewPageControl {
     func configure(imageList: [String]) {
+        imageDataSources.accept(imageList)
         pagecontrolImageView.kf.setImage(with: URL(string: imageList[0]))
+        pageControl.numberOfPages = imageList.count
     }
 }

--- a/Projects/Core/DesignSystem/Sources/ImageViewPageControl.swift
+++ b/Projects/Core/DesignSystem/Sources/ImageViewPageControl.swift
@@ -1,0 +1,92 @@
+import UIKit
+import SnapKit
+import Then
+import Kingfisher
+import RxSwift
+import RxCocoa
+import RxGesture
+
+class ImageViewPageControl: UIView {
+    private let disposeBag = DisposeBag()
+    private let imageDataSources = BehaviorRelay<[String]>(value: [])
+    
+    private let pagecontrolImageView = UIImageView().then {
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 10
+        $0.backgroundColor = DesignSystemAsset.Colors.gray.color
+//        $0.image = bannerImageSources[0]
+    }
+    
+    private let pageControl = UIPageControl().then {
+        $0.pageIndicatorTintColor = DesignSystemAsset.Colors.gray.color
+        $0.currentPageIndicatorTintColor = DesignSystemAsset.Colors.mainColor.color
+        $0.isUserInteractionEnabled = false
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addView()
+        setLayout()
+        setGesture()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setGesture() {
+        Observable
+            .merge(
+                pagecontrolImageView.rx.gesture(.swipe(direction: .left)).asObservable(),
+                pagecontrolImageView.rx.gesture(.swipe(direction: .right)).asObservable()
+            )
+            .bind(with: self) { owner, gesture in
+                guard let gesture = gesture as? UISwipeGestureRecognizer else { return }
+                
+                switch gesture.direction {
+                case .left:
+                    owner.pageControl.currentPage += 1
+                case .right:
+                    owner.pageControl.currentPage -= 1
+                default:
+                    break
+                }
+                
+                UIView.transition(
+                    with: owner.pagecontrolImageView,
+                    duration: 0.3,
+                    options: .transitionCrossDissolve,
+                    animations: {
+                        owner.pagecontrolImageView.kf.setImage(with: URL(
+                            string: owner.imageDataSources.value[owner.pageControl.currentPage])
+                        )
+                    })
+            }.disposed(by: disposeBag)
+    }
+    
+    private func addView() {
+        self.addSubviews(
+            pagecontrolImageView, pageControl
+        )
+    }
+    
+    private func setLayout() {
+        pagecontrolImageView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(170)
+        }
+        
+        pageControl.snp.makeConstraints {
+            $0.top.equalTo(pagecontrolImageView.snp.bottom).offset(8)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+}
+
+extension ImageViewPageControl {
+    func configure(imageList: [String]) {
+        pagecontrolImageView.kf.setImage(with: URL(string: imageList[0]))
+    }
+}

--- a/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
@@ -85,7 +85,18 @@ class HomeViewController: BaseVC<HomeViewModel> {
         segmentedControl.setDividerImage(image, forLeftSegmentState: .selected, rightSegmentState: .normal, barMetrics: .default)
     }
     
-    func bindUI() {
+    private func addSegmentedControlUnderLinde() {
+        let width = (segmentedControl.bounds.size.width / CGFloat(segmentedControl.numberOfSegments)) - 18
+        let height: CGFloat = 2.0
+        let xPosition = CGFloat(segmentedControl.selectedSegmentIndex) * width
+        print(xPosition)
+        let yPosition = segmentedControl.bounds.size.height + 23 - height
+        let frame = CGRect(x: xPosition + 9, y: yPosition, width: width, height: height)
+        underlineView.frame = frame
+        segmentedControl.addSubview(underlineView)
+    }
+    
+    private func bindUI() {
         moviesData
             .asDriver()
             .drive(moviesCollectionView.rx.items(
@@ -135,16 +146,7 @@ class HomeViewController: BaseVC<HomeViewModel> {
         bindUI()
         moviesCollectionView.delegate = self
         removeBackgroundAndDidiver()
-        
-        let width = (segmentedControl.bounds.size.width / CGFloat(segmentedControl.numberOfSegments)) - 18
-        let height: CGFloat = 2.0
-        print("width = \(width)")
-        let xPosition = CGFloat(segmentedControl.selectedSegmentIndex) * width
-        print(xPosition)
-        let yPosition = segmentedControl.bounds.size.height + 23 - height
-        let frame = CGRect(x: xPosition + 9, y: yPosition, width: width, height: height)
-        underlineView.frame = frame
-        segmentedControl.addSubview(underlineView)
+        addSegmentedControlUnderLinde()
         
         moviesData.accept([MoviesModel(imageUrl: "https://www.kukinews.com/data/kuk/image/2022/05/18/kuk202205180005.680x.0.jpg"), MoviesModel(imageUrl: "https://www.kukinews.com/data/kuk/image/2022/05/18/kuk202205180005.680x.0.jpg"), MoviesModel(imageUrl: "https://www.kukinews.com/data/kuk/image/2022/05/18/kuk202205180005.680x.0.jpg"), MoviesModel(imageUrl: "https://www.kukinews.com/data/kuk/image/2022/05/18/kuk202205180005.680x.0.jpg"), MoviesModel(imageUrl: "https://www.kukinews.com/data/kuk/image/2022/05/18/kuk202205180005.680x.0.jpg")])
     }

--- a/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
@@ -36,6 +36,7 @@ class HomeViewController: BaseVC<HomeViewModel> {
     }
     
     private let bannerImageView = UIImageView().then {
+        $0.backgroundColor = DesignSystemAsset.Colors.gray.color
         $0.layer.cornerRadius = 10
         $0.image = bannerImageSources[0]
     }

--- a/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
@@ -42,7 +42,7 @@ class HomeViewController: BaseVC<HomeViewModel> {
     
     private let underlineView = UIView().then {
         $0.backgroundColor = DesignSystemAsset.Colors.mainColor.color
-        $0.layer.cornerRadius = 10
+//        $0.layer.cornerRadius = 0.5
     }
 
     private let segmentedControl = UISegmentedControl(items: ["최근", "추천", "인기"]).then {
@@ -109,7 +109,7 @@ class HomeViewController: BaseVC<HomeViewModel> {
         
         segmentedControl.rx.selectedSegmentIndex.changed
             .bind(with: self) { owner, _ in
-                let underlineFinalXPosition = (self.segmentedControl.bounds.width / CGFloat(self.segmentedControl.numberOfSegments)) * CGFloat(self.segmentedControl.selectedSegmentIndex)
+                let underlineFinalXPosition = ((self.segmentedControl.bounds.width / CGFloat(self.segmentedControl.numberOfSegments)) * CGFloat(self.segmentedControl.selectedSegmentIndex)) + 9
                 UIView.animate(
                     withDuration: 0.1,
                     animations: {
@@ -129,23 +129,20 @@ class HomeViewController: BaseVC<HomeViewModel> {
             }.disposed(by: disposeBag)
     }
     
-    override func viewWillLayoutSubviews() {
-        
-    }
-    
     override func configureVC() {
-        print("viewDidLoad")
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.rightBarButtonItem = profileButton
         bindUI()
         moviesCollectionView.delegate = self
         removeBackgroundAndDidiver()
         
-        let width = segmentedControl.bounds.size.width / CGFloat(segmentedControl.numberOfSegments)
+        let width = (segmentedControl.bounds.size.width / CGFloat(segmentedControl.numberOfSegments)) - 18
         let height: CGFloat = 2.0
+        print("width = \(width)")
         let xPosition = CGFloat(segmentedControl.selectedSegmentIndex) * width
-        let yPosition = segmentedControl.bounds.size.height - height
-        let frame = CGRect(x: xPosition, y: yPosition, width: width, height: height)
+        print(xPosition)
+        let yPosition = segmentedControl.bounds.size.height + 23 - height
+        let frame = CGRect(x: xPosition + 9, y: yPosition, width: width, height: height)
         underlineView.frame = frame
         segmentedControl.addSubview(underlineView)
         
@@ -214,10 +211,6 @@ class HomeViewController: BaseVC<HomeViewModel> {
             $0.leading.equalToSuperview().inset(15)
             $0.height.equalTo(23)
         }
- 
-//        segmentedControl.snp.makeConstraints {
-//            $0.center.equalToSuperview()
-//        }
 
         moviesCollectionView.snp.makeConstraints {
             $0.top.equalTo(segmentedControl.snp.bottom).offset(20)

--- a/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/HomeViewController.swift
@@ -35,20 +35,9 @@ class HomeViewController: BaseVC<HomeViewModel> {
         $0.tintColor = .white
     }
     
-    private let bannerImageView = UIImageView().then {
+    private let bannerImageView = ImageViewPageControl().then {
         $0.backgroundColor = DesignSystemAsset.Colors.gray.color
         $0.layer.cornerRadius = 10
-        $0.image = bannerImageSources[0]
-    }
-    
-    private let pageControl = UIPageControl().then {
-        $0.isUserInteractionEnabled = false
-        $0.currentPage = 0
-        $0.numberOfPages = bannerImageSources.count
-        $0.setCurrentPageIndicatorImage(
-            DesignSystemAsset.Images.pagecontrol.image,
-            forPage: $0.currentPage
-        )
     }
     
     private let underlineView = UIView().then {
@@ -58,11 +47,11 @@ class HomeViewController: BaseVC<HomeViewModel> {
 
     private let segmentedControl = UISegmentedControl(items: ["최근", "추천", "인기"]).then {
         $0.selectedSegmentIndex = 0
-//        $0.setTitleTextAttributes([
-//            NSAttributedString.Key.foregroundColor: DesignSystemAsset.Colors.darkGray.color,
-//            NSAttributedString.Key.font: DesignSystemFontFamily.Suit.semiBold.font(size: 16)
-//        ], for: .normal)
-//        $0.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
+        $0.setTitleTextAttributes([
+            .foregroundColor: DesignSystemAsset.Colors.darkGray.color,
+            .font: DesignSystemFontFamily.Suit.semiBold.font(size: 16)
+        ], for: .normal)
+        $0.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
     }
     
     lazy var moviesCollectionView: UICollectionView = {
@@ -94,34 +83,6 @@ class HomeViewController: BaseVC<HomeViewModel> {
         segmentedControl.setBackgroundImage(image, for: .highlighted, barMetrics: .default)
         
         segmentedControl.setDividerImage(image, forLeftSegmentState: .selected, rightSegmentState: .normal, barMetrics: .default)
-    }
-    
-    private func setGesture() {
-        Observable
-            .merge(
-                bannerImageView.rx.gesture(.swipe(direction: .left)).asObservable(),
-                bannerImageView.rx.gesture(.swipe(direction: .right)).asObservable()
-            )
-            .bind(with: self) { owner, gesture in
-                guard let gesture = gesture as? UISwipeGestureRecognizer else { return }
-                
-                switch gesture.direction {
-                case .left:
-                    owner.pageControl.currentPage += 1
-                case .right:
-                    owner.pageControl.currentPage -= 1
-                default:
-                    break
-                }
-                
-                UIView.transition(
-                    with: owner.bannerImageView,
-                    duration: 0.3,
-                    options: .transitionCrossDissolve,
-                    animations: {
-                        owner.bannerImageView.image = bannerImageSources[owner.pageControl.currentPage]
-                    })
-            }.disposed(by: disposeBag)
     }
     
     func bindUI() {
@@ -169,20 +130,21 @@ class HomeViewController: BaseVC<HomeViewModel> {
     }
     
     override func viewWillLayoutSubviews() {
-        removeBackgroundAndDidiver()
+        
     }
     
     override func configureVC() {
+        print("viewDidLoad")
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.rightBarButtonItem = profileButton
-        setGesture()
         bindUI()
         moviesCollectionView.delegate = self
+        removeBackgroundAndDidiver()
         
         let width = segmentedControl.bounds.size.width / CGFloat(segmentedControl.numberOfSegments)
         let height: CGFloat = 2.0
         let xPosition = CGFloat(segmentedControl.selectedSegmentIndex) * width
-        let yPosition = segmentedControl.bounds.size.height - height - 9
+        let yPosition = segmentedControl.bounds.size.height - height
         let frame = CGRect(x: xPosition, y: yPosition, width: width, height: height)
         underlineView.frame = frame
         segmentedControl.addSubview(underlineView)
@@ -212,6 +174,7 @@ class HomeViewController: BaseVC<HomeViewModel> {
         if keyPath == ContentSizeKey.key {
             if object is UITableView {
                 if let newValue = change?[.newKey] as? CGSize {
+                    print(newValue)
                     crowdFundingTableView.snp.updateConstraints {
                         $0.height.equalTo(newValue.height + 50)
                     }
@@ -225,12 +188,10 @@ class HomeViewController: BaseVC<HomeViewModel> {
         scrollView.addSubview(contentView)
 
         contentView.addSubviews(
-            segmentedControl, pageControl,
-            bannerImageView, moviesCollectionView,
-            crowdFundingTitleLabel, crowdFundingTableView
+            bannerImageView, segmentedControl,
+            moviesCollectionView, crowdFundingTitleLabel,
+            crowdFundingTableView
         )
-        
-        segmentedControl.center = view.center
     }
     
     override func setLayout() {
@@ -247,20 +208,19 @@ class HomeViewController: BaseVC<HomeViewModel> {
             $0.leading.trailing.equalToSuperview().inset(15)
             $0.height.equalTo(170)
         }
-
-        pageControl.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(bannerImageView.snp.bottom).offset(16)
+        
+        segmentedControl.snp.makeConstraints {
+            $0.top.equalTo(bannerImageView.snp.bottom).offset(20)
+            $0.leading.equalToSuperview().inset(15)
+            $0.height.equalTo(23)
         }
  
 //        segmentedControl.snp.makeConstraints {
-//            $0.top.equalTo(pageControl.snp.bottom).offset(20)
-//            $0.leading.equalToSuperview().inset(15)
-//            $0.height.equalTo(23)
+//            $0.center.equalToSuperview()
 //        }
 
         moviesCollectionView.snp.makeConstraints {
-            $0.top.equalTo(pageControl.snp.bottom).offset(20)
+            $0.top.equalTo(segmentedControl.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(150)
         }
@@ -274,7 +234,7 @@ class HomeViewController: BaseVC<HomeViewModel> {
             $0.top.equalTo(crowdFundingTitleLabel.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
-            $0.height.equalTo(100)
+            $0.height.equalTo(1)
         }
     }
 }


### PR DESCRIPTION
## 제목
PageControl 을 컴포넌트화 시키고 SegmentedControl layout 문제를 해결했습니다.

## PageControl 컴포넌트화
컴포넌트화를 통해 크라우드 펀딩 디테일 페이지에 적용했고, 홈에 배너는 아직 API 가 완성되지 않아 적용하지 못 했습니다.
- 완성되면 API 연동 후 적용할 예정.

## SegmentedControl Layout Issue
SegmentedControl 에 constraint를 추가하면 시뮬레이터가 까맣게 보이는 문제가 있었습니다.
<img width="344" alt="스크린샷 2023-07-06 오전 9 03 57" src="https://github.com/Dan-Bam/IndiStraw-iOS/assets/81687906/e43591b3-d104-48b0-921a-317597df9b48">

추측상 원인은 segmentedControl 을 custom 하기위해 사용했던 ```removeBackgroundAndDidiver``` 의 함수 호출 시점이 ```viewWillLayoutSubViews``` 였고 때문에 함수 호출 시점에 문제가 생겼던 것 같습니다. 

 해당 함수를 ```viewDidLoad```로 이동 시켰고 해결했습니다.